### PR TITLE
runtime: add docker runtime to MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,89 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# VS Code
+.vscode/

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 .codeclimate.yml
 .travis.yml
 .taskcluster.yml
+.pre-commit-config.yaml
 
 # Docker
 docker-compose.yml
@@ -56,6 +57,11 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+.pytest_cache/
+tests/
+
+# Linting
+.ruff_cache/
 
 # Translations
 *.mo
@@ -87,3 +93,6 @@ venv/
 
 # VS Code
 .vscode/
+
+# Other
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Use a Python image with uv pre-installed
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+
+# Install the project into `/app`
+WORKDIR /app
+
+# Enable bytecode compilation
+ENV UV_COMPILE_BYTECODE=1
+
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
+
+# Install the project's dependencies using the lockfile and settings
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --no-install-project --no-dev --no-editable
+
+# Then, add the rest of the project source code and install it
+# Installing separately from its dependencies allows optimal layer caching
+ADD . /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable
+
+# Place executables in the environment at the front of the path
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Set entry point
+ENTRYPOINT ["mcp-yahoo-finance"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCP Yahoo Finance
 
-A Model Context Protocol (MCP) server for Yahoo Finance interaction. This server provides tools to get pricing, company information and more.
+A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for Yahoo Finance interaction. This server provides tools to get pricing, company information and more.
 
 > Please note that `mcp-yahoo-finance` is currently in early development. The functionality and available tools are subject to change and expansion as I continue to develop and improve the server.
 
@@ -30,7 +30,6 @@ uv sync
 
 ## Configuration
 
-
 ### Claude Desktop
 
 Add this to your `claude_desktop_config.json`:
@@ -41,6 +40,18 @@ Add this to your `claude_desktop_config.json`:
         "yahoo-finance": {
             "command": "uvx",
             "args": ["mcp-yahoo-finance"]
+        }
+    }
+}
+```
+You can also use docker:
+
+```json
+{
+    "mcpServers": {
+        "yahoo-finance": {
+            "command": "docker",
+            "args": ["run", "-i", "--rm" "IMAGE"]
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also use docker:
     "mcpServers": {
         "yahoo-finance": {
             "command": "docker",
-            "args": ["run", "-i", "--rm" "IMAGE"]
+            "args": ["run", "-i", "--rm", "IMAGE"]
         }
     }
 }


### PR DESCRIPTION
This feature allows for running the `mcp-yahoo-finance` server with Docker in addition to `uv`.

- Added Dockerfile for building and running the MCP Yahoo Finance server
- Documented Docker usage in `claude_desktop_config.json` example.