### PR TITLE
Adding Tool commands related to Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Add this to your `.vscode/mcp.json`:
 1. "What is the stock price of Apple?"
 2. "What is the difference in stock price between Apple and Google?"
 3. "How much did the stock price of Apple change between 2024-01-01 and 2025-01-01?"
+4. "What are the available options expiration dates for AAPL?"
+5. "Show me the options chain for AAPL expiring on 2024-01-19"
+6. "What are the call and put options for Tesla?"
 
 ## Build
 

--- a/src/mcp_yahoo_finance/server.py
+++ b/src/mcp_yahoo_finance/server.py
@@ -174,6 +174,48 @@ class YahooFinance:
             return f"{recommendations.to_json(orient='records', indent=2)}"
         return f"{recommendations}"
 
+    def get_option_expiration_dates(self, symbol: str) -> str:
+        """Get available options expiration dates for a given stock symbol.
+
+        Args:
+            symbol (str): Stock symbol in Yahoo Finance format.
+        """
+        stock = Ticker(ticker=symbol, session=self.session)
+        expiration_dates = stock.options
+        return json.dumps(list(expiration_dates), indent=2)
+
+    def get_option_chain(self, symbol: str, expiration_date: str) -> str:
+        """Get options chain for a specific expiration date.
+
+        Args:
+            symbol (str): Stock symbol in Yahoo Finance format.
+            expiration_date (str): Options expiration date in YYYY-MM-DD format.
+        """
+        stock = Ticker(ticker=symbol, session=self.session)
+        option_chain = stock.option_chain(expiration_date)
+        
+        result = {
+            "calls": None,
+            "puts": None,
+            "underlying": option_chain.underlying
+        }
+        
+        if option_chain.calls is not None:
+            # Convert dates to strings for JSON serialization
+            calls_df = option_chain.calls.copy()
+            if 'lastTradeDate' in calls_df.columns:
+                calls_df['lastTradeDate'] = calls_df['lastTradeDate'].astype(str)
+            result["calls"] = calls_df.to_dict(orient='records')
+        
+        if option_chain.puts is not None:
+            # Convert dates to strings for JSON serialization
+            puts_df = option_chain.puts.copy()
+            if 'lastTradeDate' in puts_df.columns:
+                puts_df['lastTradeDate'] = puts_df['lastTradeDate'].astype(str)
+            result["puts"] = puts_df.to_dict(orient='records')
+        
+        return json.dumps(result, indent=2)
+
 
 async def serve() -> None:
     server = Server("mcp-yahoo-finance")
@@ -192,6 +234,8 @@ async def serve() -> None:
             generate_tool(yf.get_earning_dates),
             generate_tool(yf.get_news),
             generate_tool(yf.get_recommendations),
+            generate_tool(yf.get_option_expiration_dates),
+            generate_tool(yf.get_option_chain),
         ]
 
     @server.call_tool()
@@ -227,6 +271,12 @@ async def serve() -> None:
             case "get_recommendations":
                 recommendations = yf.get_recommendations(**args)
                 return [TextContent(type="text", text=recommendations)]
+            case "get_option_expiration_dates":
+                dates = yf.get_option_expiration_dates(**args)
+                return [TextContent(type="text", text=dates)]
+            case "get_option_chain":
+                chain = yf.get_option_chain(**args)
+                return [TextContent(type="text", text=chain)]
             case _:
                 raise ValueError(f"Unknown tool: {name}")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,6 +41,9 @@ def client_tools() -> list[Tool]:
         "get_cashflow",
         "get_earning_dates",
         "get_news",
+        "get_recommendations",
+        "get_option_expiration_dates",
+        "get_option_chain",
     ],
 )
 async def test_list_tools(client_tools: list[Tool], tool_name) -> None:


### PR DESCRIPTION
This pull request adds support for querying stock options data, including available expiration dates and options chains, to the Yahoo Finance API server. The main changes introduce two new API methods for fetching options data, expose them as tools, and update tests and documentation accordingly.

### Options data support

* Added `get_option_expiration_dates` and `get_option_chain` methods to `McpYahooFinance` for retrieving available expiration dates and options chains for a given stock symbol, including call and put options with proper JSON serialization.

### API and tool registration

* Registered the new options-related methods as tools in the `list_tools` API endpoint, making them available for client use.
* Updated the `call_tool` dispatcher to handle requests for the new options methods and return their results.

### Documentation and testing

* Added example queries for options data to the `README.md` to demonstrate usage.
* Updated the test suite to include the new options tools in the expected tool list for server tests.