### PR TITLE
fix: update lockfile before sync in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Update lockfile
+      run: |
+        uv lock
+
     - name: Install Dependencies
       run: |
         uv sync --locked --all-extras


### PR DESCRIPTION
- Add uv lock step before uv sync --locked to handle dependency updates
- Fixes CI failure when dependabot updates dependencies