### PR TITLE
test: speed up test suite by using generate_tool directly

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,31 +1,29 @@
-import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
-from mcp import ClientSession
-from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.types import Tool
 
-
-@pytest.fixture
-def server_params():
-    return StdioServerParameters(command="mcp-yahoo-finance")
+from mcp_yahoo_finance.server import YahooFinance
+from mcp_yahoo_finance.utils import generate_tool
 
 
 @pytest.fixture
 def client_tools() -> list[Tool]:
-    server_params = StdioServerParameters(command="mcp-yahoo-finance")
-
-    async def _get_tools():
-        async with (
-            stdio_client(server_params) as (read, write),
-            ClientSession(read, write) as session,
-        ):
-            await session.initialize()
-            tool_list_result = await session.list_tools()
-            return tool_list_result.tools
-
-    return asyncio.run(_get_tools())
+    yf = YahooFinance()
+    return [
+        generate_tool(yf.get_current_stock_price),
+        generate_tool(yf.get_stock_price_by_date),
+        generate_tool(yf.get_stock_price_date_range),
+        generate_tool(yf.get_historical_stock_prices),
+        generate_tool(yf.get_dividends),
+        generate_tool(yf.get_income_statement),
+        generate_tool(yf.get_cashflow),
+        generate_tool(yf.get_earning_dates),
+        generate_tool(yf.get_news),
+        generate_tool(yf.get_recommendations),
+        generate_tool(yf.get_option_expiration_dates),
+        generate_tool(yf.get_option_chain),
+    ]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.5.1" },
-    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.15.10" },
 ]


### PR DESCRIPTION
Speed up test suite by using generate_tool directly instead of spawning a full MCP server process for each test.

## Changes

- Replaced `client_tools` fixture to use `generate_tool(yf.method)` directly rather than starting a `StdioServerParameters` `process
- Updated pytest from 8.3.5 to 9.0.3 in uv.lock

## Why

The original approach spawned a full MCP server process for each test, adding significant overhead. Using `generate_tool` directly eliminates this process spawn, dramatically reducing test execution time.