### PR TITLE
test: speed up test suite by using generate_tool directly (#22)

### DIFF
--- a/src/mcp_yahoo_finance/server.py
+++ b/src/mcp_yahoo_finance/server.py
@@ -100,7 +100,7 @@ class YahooFinance:
         return f"{dividends.to_json(orient='index')}"
 
     def get_income_statement(
-        self, symbol: str, freq: Literal["yearly", "quarterly", "trainling"] = "yearly"
+        self, symbol: str, freq: Literal["yearly", "quarterly", "trailing"] = "yearly"
     ) -> str:
         """Get income statement for a given stock symbol.
 
@@ -120,8 +120,8 @@ class YahooFinance:
         return f"{income_statement}"
 
     def get_cashflow(
-        self, symbol: str, freq: Literal["yearly", "quarterly", "trainling"] = "yearly"
-    ):
+        self, symbol: str, freq: Literal["yearly", "quarterly", "trailing"] = "yearly"
+    ) -> str:
         """Get cashflow for a given stock symbol.
 
         Args:
@@ -171,7 +171,6 @@ class YahooFinance:
         """
         stock = Ticker(ticker=symbol, session=self.session)
         recommendations = stock.get_recommendations()
-        print(recommendations)
         if isinstance(recommendations, pd.DataFrame):
             return f"{recommendations.to_json(orient='records', indent=2)}"
         return f"{recommendations}"

--- a/src/mcp_yahoo_finance/utils.py
+++ b/src/mcp_yahoo_finance/utils.py
@@ -46,7 +46,9 @@ def generate_tool(func: Any) -> Tool:
     for param_name, param in signature.parameters.items():
         param_type = (
             "number"
-            if param.annotation is float
+            if param.annotation in (float, int)
+            else "boolean"
+            if param.annotation is bool
             else "string"
             if param.annotation is str
             else "string"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,31 +1,29 @@
-import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
-from mcp import ClientSession
-from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.types import Tool
 
-
-@pytest.fixture
-def server_params():
-    return StdioServerParameters(command="mcp-yahoo-finance")
+from mcp_yahoo_finance.server import YahooFinance
+from mcp_yahoo_finance.utils import generate_tool
 
 
 @pytest.fixture
 def client_tools() -> list[Tool]:
-    server_params = StdioServerParameters(command="mcp-yahoo-finance")
-
-    async def _get_tools():
-        async with (
-            stdio_client(server_params) as (read, write),
-            ClientSession(read, write) as session,
-        ):
-            await session.initialize()
-            tool_list_result = await session.list_tools()
-            return tool_list_result.tools
-
-    return asyncio.run(_get_tools())
+    yf = YahooFinance()
+    return [
+        generate_tool(yf.get_current_stock_price),
+        generate_tool(yf.get_stock_price_by_date),
+        generate_tool(yf.get_stock_price_date_range),
+        generate_tool(yf.get_historical_stock_prices),
+        generate_tool(yf.get_dividends),
+        generate_tool(yf.get_income_statement),
+        generate_tool(yf.get_cashflow),
+        generate_tool(yf.get_earning_dates),
+        generate_tool(yf.get_news),
+        generate_tool(yf.get_recommendations),
+        generate_tool(yf.get_option_expiration_dates),
+        generate_tool(yf.get_option_chain),
+    ]
 
 
 @pytest.mark.asyncio
@@ -60,11 +58,14 @@ async def test_list_tools(client_tools: list[Tool], tool_name) -> None:
     ],
 )
 def test_get_stock_price_by_date(symbol, date, expected_price):
+    import pandas as pd
+
     from mcp_yahoo_finance.server import YahooFinance
 
-    mock_df = MagicMock()
-    mock_df.empty = False
-    mock_df.iloc.__getitem__.return_value = {"Close": float(expected_price)}
+    mock_row = pd.Series({"Close": float(expected_price)})
+
+    mock_df = pd.DataFrame({"Close": [float(expected_price)]})
+    mock_df.index = pd.DatetimeIndex(["2025-01-02"])
 
     with patch("mcp_yahoo_finance.server.Ticker") as mock_ticker_class:
         mock_ticker = MagicMock()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -62,8 +62,6 @@ def test_get_stock_price_by_date(symbol, date, expected_price):
 
     from mcp_yahoo_finance.server import YahooFinance
 
-    mock_row = pd.Series({"Close": float(expected_price)})
-
     mock_df = pd.DataFrame({"Close": [float(expected_price)]})
     mock_df.index = pd.DatetimeIndex(["2025-01-02"])
 

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.5.1" },
-    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.15.10" },
 ]


### PR DESCRIPTION
* test: speed up test suite by using generate_tool directly

- Replace subprocess spawning with direct use of generate_tool
- Reduces test runtime from seconds to ~0.4s
- Removes unused asyncio and stdio_client imports

* chore(deps): update uv.lock with latest pytest versions