### PR TITLE
refactor: extract duplicate code and improve type inference

### DIFF
--- a/src/mcp_yahoo_finance/server.py
+++ b/src/mcp_yahoo_finance/server.py
@@ -257,6 +257,13 @@ class YahooFinance:
             stock = Ticker(ticker=symbol, session=self.session)
             option_chain = stock.option_chain(expiration_date)
 
+            def _convert_dates(df: pd.DataFrame) -> pd.DataFrame:
+                if df is None or "lastTradeDate" not in df.columns:
+                    return df
+                df = df.copy()
+                df["lastTradeDate"] = df["lastTradeDate"].astype(str)
+                return df
+
             result = {
                 "calls": None,
                 "puts": None,
@@ -264,16 +271,14 @@ class YahooFinance:
             }
 
             if option_chain.calls is not None:
-                calls_df = option_chain.calls.copy()
-                if "lastTradeDate" in calls_df.columns:
-                    calls_df["lastTradeDate"] = calls_df["lastTradeDate"].astype(str)
-                result["calls"] = calls_df.to_dict(orient="records")
+                result["calls"] = _convert_dates(option_chain.calls).to_dict(
+                    orient="records"
+                )
 
             if option_chain.puts is not None:
-                puts_df = option_chain.puts.copy()
-                if "lastTradeDate" in puts_df.columns:
-                    puts_df["lastTradeDate"] = puts_df["lastTradeDate"].astype(str)
-                result["puts"] = puts_df.to_dict(orient="records")
+                result["puts"] = _convert_dates(option_chain.puts).to_dict(
+                    orient="records"
+                )
 
             return json.dumps(result, indent=2)
         except Exception as e:

--- a/src/mcp_yahoo_finance/utils.py
+++ b/src/mcp_yahoo_finance/utils.py
@@ -1,6 +1,6 @@
 import inspect
 from datetime import datetime
-from typing import Any
+from typing import Any, Union, get_origin
 
 from mcp.types import Tool
 
@@ -29,6 +29,30 @@ def parse_docstring(docstring: str) -> dict[str, str]:
     return descriptions
 
 
+def _infer_json_type(annotation: Any) -> str:
+    """Infer JSON schema type from Python type annotation."""
+    if annotation is None or annotation is inspect.Parameter.empty:
+        return "string"
+
+    origin = get_origin(annotation)
+
+    if origin is Union:
+        args = annotation.__args__
+        for arg in args:
+            if arg is type(None):
+                continue
+            return _infer_json_type(arg)
+
+    if annotation in (int, float):
+        return "number"
+    if annotation is bool:
+        return "boolean"
+    if annotation is str:
+        return "string"
+
+    return "string"
+
+
 def generate_tool(func: Any) -> Tool:
     """Generates a tool schema from a Python function."""
     signature = inspect.signature(func)
@@ -45,15 +69,7 @@ def generate_tool(func: Any) -> Tool:
     }
 
     for param_name, param in signature.parameters.items():
-        param_type = (
-            "number"
-            if param.annotation in (float, int)
-            else "boolean"
-            if param.annotation is bool
-            else "string"
-            if param.annotation is str
-            else "string"
-        )
+        param_type = _infer_json_type(param.annotation)
         schema["inputSchema"]["properties"][param_name] = {
             "type": param_type,
             "description": param_descriptions.get(param_name, ""),


### PR DESCRIPTION
- Extract _convert_dates() helper in get_option_chain to remove duplication
- Add _infer_json_type() to handle Union types and better type detection
- Replace fragile identity checks with proper typing.get_origin() usage